### PR TITLE
Simplify `ProjectReachability` API

### DIFF
--- a/vuln-reach-cli/src/main.rs
+++ b/vuln-reach-cli/src/main.rs
@@ -112,12 +112,12 @@ impl ProjectDef {
         // Build the project object.
         let project = Project::new(package_resolver, packages);
 
-        // Compute reachability.
-        let reachability = project.reachability(self.vuln.into_iter());
+        // Compute reachability for each node.
+        for node in &self.vuln {
+            let reachability = project.reachability(node);
 
-        let paths = reachability.find_paths(&self.name);
+            let path = reachability.find_path(&self.name);
 
-        for (node, path) in paths {
             match path {
                 Some(path) => {
                     println!(

--- a/vuln-reach/src/javascript/project/mod.rs
+++ b/vuln-reach/src/javascript/project/mod.rs
@@ -473,7 +473,7 @@ mod tests {
     use textwrap::dedent;
 
     use super::*;
-    use crate::javascript::module::{MemModuleResolver};
+    use crate::javascript::module::MemModuleResolver;
     use crate::javascript::package::Package;
 
     macro_rules! mem_fixture {

--- a/vuln-reach/src/javascript/project/mod.rs
+++ b/vuln-reach/src/javascript/project/mod.rs
@@ -473,7 +473,7 @@ mod tests {
     use textwrap::dedent;
 
     use super::*;
-    use crate::javascript::module::MemModuleResolver;
+    use crate::javascript::module::{MemModuleResolver};
     use crate::javascript::package::Package;
 
     macro_rules! mem_fixture {


### PR DESCRIPTION
This PR simplifies the top-level client facing API.

The requirement for using an iterator of vulnerable nodes in `ProjectReachability` is dropped, allowing the user to design their own iteration logic and simplifying the use case of checking against a single vulnerable node.