### PR TITLE
Add `edges_from` method to `ProjectReachability`

### DIFF
--- a/vuln-reach/src/javascript/project/mod.rs
+++ b/vuln-reach/src/javascript/project/mod.rs
@@ -75,6 +75,11 @@ impl ProjectReachability {
         Self(adjacency_lists)
     }
 
+    /// Return the graph edges leaving from the specified package, if they exist.
+    pub fn edges_from(&self, package: &str) -> Option<&Vec<ReachabilityEdge>> {
+        self.0.get(package)
+    }
+
     /// Find one possible path from the specified package to the vulnerable
     /// node.
     pub fn find_path<S: AsRef<str>>(&self, start_package: S) -> Option<ReachabilityPath> {

--- a/vuln-reach/src/javascript/project/mod.rs
+++ b/vuln-reach/src/javascript/project/mod.rs
@@ -75,7 +75,8 @@ impl ProjectReachability {
         Self(adjacency_lists)
     }
 
-    /// Return the graph edges leaving from the specified package, if they exist.
+    /// Return the graph edges leaving from the specified package, if they
+    /// exist.
     pub fn edges_from(&self, package: &str) -> Option<&Vec<ReachabilityEdge>> {
         self.0.get(package)
     }


### PR DESCRIPTION
This PR adds a convenience method for retrieving edges that start from a given package in a `ProjectReachability` graph object.