### PR TITLE
Add API types to vuln-reach

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,8 @@ resolver = "2"
 members = [
   "vuln-reach",
   "vuln-reach-cli",
+  "vulnreach_types",
 ]
+
+[workspace.package]
+rust-version = "1.65.0"

--- a/vulnreach_types/Cargo.toml
+++ b/vulnreach_types/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "vulnreach_types"
+version = "0.1.0"
+authors = ["Phylum, Inc. <engineering@phylum.io>"]
+edition = "2021"
+rust-version.workspace = true
+
+[dependencies]
+serde = { version = "1.0.152", features = ["derive"] }

--- a/vulnreach_types/src/lib.rs
+++ b/vulnreach_types/src/lib.rs
@@ -1,5 +1,7 @@
 //! Types for the vulnerability reachability API.
 
+use std::collections::HashSet;
+
 use serde::{Deserialize, Serialize};
 
 /// Identified import vulnerability.
@@ -40,4 +42,23 @@ pub struct Callsite {
     pub start: (usize, usize),
     pub end: (usize, usize),
     pub text: String,
+}
+
+/// A reachability analysis job.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub struct Job {
+    /// Job ID for the Phylum issue analysis.
+    pub analysis_job_id: String,
+    /// The list of transitive dependencies for the user's project.
+    pub dependencies: HashSet<JobPackage>,
+    /// The list of packages directly imported by the user.
+    pub imported_packages: HashSet<String>,
+}
+
+/// A globally unique package.
+#[derive(Serialize, Deserialize, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Debug)]
+pub struct JobPackage {
+    pub name: String,
+    pub version: String,
+    pub ecosystem: String,
 }

--- a/vulnreach_types/src/lib.rs
+++ b/vulnreach_types/src/lib.rs
@@ -1,0 +1,43 @@
+//! Types for the vulnerability reachability API.
+
+use serde::{Deserialize, Serialize};
+
+/// Identified import vulnerability.
+#[derive(Serialize, Deserialize, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Debug)]
+pub struct Vulnerability {
+    pub name: String,
+    pub summary: String,
+    pub date: String,
+    pub severity: u8,
+    pub description: String,
+    /// Array storing the reachability path through each affected dependency.
+    ///
+    /// # Example:
+    ///
+    /// ```ignore
+    /// // Packages reduced to their name for brevity.
+    /// [
+    ///     [server, http, vulnerable],
+    ///     [client, http, vulnerable],
+    /// ]
+    /// ```
+    pub vulnerable_dependencies: Vec<Vec<Package>>,
+}
+
+/// Dependency package.
+#[derive(Serialize, Deserialize, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Debug)]
+pub struct Package {
+    pub name: String,
+    pub version: String,
+    /// Path taken through this dependency to reach the next vulnerable node.
+    pub path: Vec<Callsite>,
+}
+
+/// Import usage location.
+#[derive(Serialize, Deserialize, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Debug)]
+pub struct Callsite {
+    pub file: String,
+    pub start: (usize, usize),
+    pub end: (usize, usize),
+    pub text: String,
+}


### PR DESCRIPTION
This patch adds the existing vulnreach API types to the public vuln-reach repository, allowing other tools like the CLI to reuse them without requiring access to other repositories.