### PR TITLE
Fix symbol table evaluation bug

### DIFF
--- a/vuln-reach/src/javascript/lang/symbol_table.rs
+++ b/vuln-reach/src/javascript/lang/symbol_table.rs
@@ -266,11 +266,20 @@ impl<'a> SymbolTable<'a> {
             // If formal_parameters nodes has a statement_block next sibling, it is a
             // regular function, otherwise it is an arrow function and the
             // identifier doesn't belong to a scope.
-            let body = parent.parent().unwrap().child_by_field_name("body").unwrap();
+            let function_decl = parent.parent().expect("formal_parameters node must have a parent");
+            let body = function_decl
+                .child_by_field_name("body")
+                .expect("formal_parameter parent must have a statement_block named `body`");
+
             if body.kind() == "statement_block" {
                 let scope_index = *self.scope_indices.get(&body).unwrap();
                 let scope = &self.scopes[scope_index];
-                assert!(scope.names.iter().any(|&node| self.tree.repr_of(node) == name));
+                assert!(
+                    scope.names.iter().any(|&node| self.tree.repr_of(node) == name),
+                    "Identifier {name} not found in scope ({:?}). Function:\n\n{}",
+                    scope.names,
+                    self.tree.repr_of(function_decl)
+                );
                 return Some((scope, node));
             }
         }

--- a/vuln-reach/src/javascript/lang/symbol_table.rs
+++ b/vuln-reach/src/javascript/lang/symbol_table.rs
@@ -263,8 +263,8 @@ impl<'a> SymbolTable<'a> {
         // scope is in the sibling "body" field block.
         let parent = node.parent().unwrap();
         if parent.kind() == "formal_parameters" {
-            // If formal_parameters nodes has a statement_block next sibling, it is a
-            // regular function, otherwise it is an arrow function and the
+            // If formal_parameters nodes has a statement_block among its later siblings, it
+            // is a regular function, otherwise it is an arrow function and the
             // identifier doesn't belong to a scope.
             let function_decl = parent.parent().expect("formal_parameters node must have a parent");
             let body = function_decl


### PR DESCRIPTION
This PR fixes a wrong assumption in the symbol table. 

With the previous assumption, the symbol table would fail to recognize functions that had nodes in between the parameter list and the function body. Example:

```javascript
function foo(arg1, arg2) /* comment */ { }
```

Closes #22.