### PR TITLE
Add support for anonymous functions and lambdas

### DIFF
--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -12,7 +12,7 @@ const PACKAGES: &str = include_str!("../packages");
 async fn main() {
     for package_uri in PACKAGES.lines() {
         // Ignore packages which are commented out.
-        if package_uri.starts_with('#') {
+        if package_uri.starts_with('#') | package_uri.trim().is_empty() {
             continue;
         }
 
@@ -60,11 +60,13 @@ fn assert_eq(
     for (key, upstream_value) in upstream_graph {
         let value = match graph.get(key) {
             Some(value) => value,
-            None => panic!("Missing key {key:?}"),
+            None => panic!("Head missing key {key:?}"),
         };
 
         for (key, upstream_value) in upstream_value {
             assert_eq!(value.get(key), Some(upstream_value));
         }
     }
+
+    assert_eq!(upstream_graph, graph);
 }

--- a/vuln-reach/src/javascript/lang/accesses.rs
+++ b/vuln-reach/src/javascript/lang/accesses.rs
@@ -397,107 +397,43 @@ mod tests {
 
     #[test]
     fn named_function() {
-        let tree = Tree::new(
-            r#"
+        let code = r#"
             function foo() { }
 
             function bar() {
                 foo();
             }
-            "#
-            .to_string(),
-        )
-        .unwrap();
-        let st = SymbolTable::new(&tree);
-        let accesses = AccessGraph::new(&tree, &st);
-
-        // The `foo` function
-        let foo = tree
-            .root_node()
-            .descendant_for_point_range(Point::new(1, 21), Point::new(1, 24))
-            .unwrap();
-
-        // The `bar` function
-        let bar = tree
-            .root_node()
-            .descendant_for_point_range(Point::new(3, 21), Point::new(0, 24))
-            .unwrap();
-
-        let paths = accesses.compute_paths(|access| access.node == bar, foo).unwrap();
-        println!("{paths:#?}");
-        assert!(!paths.is_empty());
+        "#;
+        assert!(is_reachable(code, "bar", "foo"));
     }
 
     #[test]
     fn named_parenthesized_function() {
-        let tree = Tree::new(
-            r#"
+        let code = r#"
             function foo() { }
 
             function bar() {
                 (foo());
             }
-            "#
-            .to_string(),
-        )
-        .unwrap();
-        let st = SymbolTable::new(&tree);
-        let accesses = AccessGraph::new(&tree, &st);
-
-        // The `foo` function
-        let foo = tree
-            .root_node()
-            .descendant_for_point_range(Point::new(1, 21), Point::new(1, 24))
-            .unwrap();
-
-        // The `bar` function
-        let bar = tree
-            .root_node()
-            .descendant_for_point_range(Point::new(3, 21), Point::new(0, 24))
-            .unwrap();
-
-        let paths = accesses.compute_paths(|access| access.node == bar, foo).unwrap();
-        println!("{paths:#?}");
-        assert!(!paths.is_empty());
+        "#;
+        assert!(is_reachable(code, "bar", "foo"));
     }
 
     #[test]
     fn immediate_named_function() {
-        let tree = Tree::new(
-            r#"
+        let code = r#"
             function foo() { }
 
             function bar() {
                 (function test() { foo(); })();
             }
-            "#
-            .to_string(),
-        )
-        .unwrap();
-        let st = SymbolTable::new(&tree);
-        let accesses = AccessGraph::new(&tree, &st);
-
-        // The `foo` function
-        let foo = tree
-            .root_node()
-            .descendant_for_point_range(Point::new(1, 21), Point::new(1, 24))
-            .unwrap();
-
-        // The `bar` function
-        let bar = tree
-            .root_node()
-            .descendant_for_point_range(Point::new(3, 21), Point::new(0, 24))
-            .unwrap();
-
-        let paths = accesses.compute_paths(|access| access.node == bar, foo).unwrap();
-        println!("{paths:#?}");
-        assert!(!paths.is_empty());
+        "#;
+        assert!(is_reachable(code, "bar", "foo"));
     }
 
     #[test]
     fn assigned_named_function() {
-        let tree = Tree::new(
-            r#"
+        let code = r#"
             function foo() { }
 
             function bar() {
@@ -506,202 +442,76 @@ mod tests {
                 };
                 xxx();
             }
-            "#
-            .to_string(),
-        )
-        .unwrap();
-        let st = SymbolTable::new(&tree);
-        let accesses = AccessGraph::new(&tree, &st);
-
-        // The `foo` function
-        let foo = tree
-            .root_node()
-            .descendant_for_point_range(Point::new(1, 21), Point::new(1, 24))
-            .unwrap();
-
-        // The `bar` function
-        let bar = tree
-            .root_node()
-            .descendant_for_point_range(Point::new(3, 21), Point::new(0, 24))
-            .unwrap();
-
-        let paths = accesses.compute_paths(|access| access.node == bar, foo).unwrap();
-        println!("{paths:#?}");
-        assert!(!paths.is_empty());
+        "#;
+        assert!(is_reachable(code, "bar", "foo"));
     }
 
     #[test]
     fn assigned_anonymous_function() {
-        let tree = Tree::new(
-            r#"
+        let code = r#"
             function foo() { }
 
             function bar() {
                 var test = function() { foo(); };
                 test();
             }
-            "#
-            .to_string(),
-        )
-        .unwrap();
-        let st = SymbolTable::new(&tree);
-        let accesses = AccessGraph::new(&tree, &st);
-
-        // The `foo` function
-        let foo = tree
-            .root_node()
-            .descendant_for_point_range(Point::new(1, 21), Point::new(1, 24))
-            .unwrap();
-
-        // The `bar` function
-        let bar = tree
-            .root_node()
-            .descendant_for_point_range(Point::new(3, 21), Point::new(0, 24))
-            .unwrap();
-
-        let paths = accesses.compute_paths(|access| access.node == bar, foo).unwrap();
-        println!("{paths:#?}");
-        assert!(!paths.is_empty());
+        "#;
+        assert!(is_reachable(code, "bar", "foo"));
     }
 
     #[test]
     fn assigned_anonymous_parenthesized_function() {
-        let tree = Tree::new(
-            r#"
+        let code = r#"
             function foo() { }
 
             function bar() {
                 var test = (((function() { foo(); })));
                 test();
             }
-            "#
-            .to_string(),
-        )
-        .unwrap();
-        let st = SymbolTable::new(&tree);
-        let accesses = AccessGraph::new(&tree, &st);
-
-        // The `foo` function
-        let foo = tree
-            .root_node()
-            .descendant_for_point_range(Point::new(1, 21), Point::new(1, 24))
-            .unwrap();
-
-        // The `bar` function
-        let bar = tree
-            .root_node()
-            .descendant_for_point_range(Point::new(3, 21), Point::new(0, 24))
-            .unwrap();
-
-        let paths = accesses.compute_paths(|access| access.node == bar, foo).unwrap();
-        println!("{paths:#?}");
-        assert!(!paths.is_empty());
+        "#;
+        assert!(is_reachable(code, "bar", "foo"));
     }
 
     #[test]
     fn immediate_anonymous_function() {
-        let tree = Tree::new(
-            r#"
+        let code = r#"
             function foo() { }
 
             function bar() {
                 (function() { foo(); })();
             }
-            "#
-            .to_string(),
-        )
-        .unwrap();
-        let st = SymbolTable::new(&tree);
-        let accesses = AccessGraph::new(&tree, &st);
-
-        // The `foo` function
-        let foo = tree
-            .root_node()
-            .descendant_for_point_range(Point::new(1, 21), Point::new(1, 24))
-            .unwrap();
-
-        // The `bar` function
-        let bar = tree
-            .root_node()
-            .descendant_for_point_range(Point::new(3, 21), Point::new(0, 24))
-            .unwrap();
-
-        let paths = accesses.compute_paths(|access| access.node == bar, foo).unwrap();
-        println!("{paths:#?}");
-        assert!(!paths.is_empty());
+        "#;
+        assert!(is_reachable(code, "bar", "foo"));
     }
 
     #[test]
     fn assigned_lambda() {
-        let tree = Tree::new(
-            r#"
+        let code = r#"
             function foo() { }
 
             function bar() {
                 var test = () => { foo(); };
                 test();
             }
-            "#
-            .to_string(),
-        )
-        .unwrap();
-        let st = SymbolTable::new(&tree);
-        let accesses = AccessGraph::new(&tree, &st);
-
-        // The `foo` function
-        let foo = tree
-            .root_node()
-            .descendant_for_point_range(Point::new(1, 21), Point::new(1, 24))
-            .unwrap();
-
-        // The `bar` function
-        let bar = tree
-            .root_node()
-            .descendant_for_point_range(Point::new(3, 21), Point::new(0, 24))
-            .unwrap();
-
-        let paths = accesses.compute_paths(|access| access.node == bar, foo).unwrap();
-        println!("{paths:#?}");
-        assert!(!paths.is_empty());
+        "#;
+        assert!(is_reachable(code, "bar", "foo"));
     }
 
     #[test]
     fn immediate_lambda() {
-        let tree = Tree::new(
-            r#"
+        let code = r#"
             function foo() { }
 
             function bar() {
                 () => { foo(); }();
             }
-            "#
-            .to_string(),
-        )
-        .unwrap();
-        let st = SymbolTable::new(&tree);
-        let accesses = AccessGraph::new(&tree, &st);
-
-        // The `foo` function
-        let foo = tree
-            .root_node()
-            .descendant_for_point_range(Point::new(1, 21), Point::new(1, 24))
-            .unwrap();
-
-        // The `bar` function
-        let bar = tree
-            .root_node()
-            .descendant_for_point_range(Point::new(3, 21), Point::new(0, 24))
-            .unwrap();
-
-        let paths = accesses.compute_paths(|access| access.node == bar, foo).unwrap();
-        println!("{paths:#?}");
-        assert!(!paths.is_empty());
+        "#;
+        assert!(is_reachable(code, "bar", "foo"));
     }
 
     #[test]
     fn immediate_unassigned_lambda() {
-        let tree = Tree::new(
-            r#"
+        let code = r#"
             function foo() { }
 
             function bar() {
@@ -709,27 +519,47 @@ mod tests {
                     () => { foo(); };
                 })();
             }
-            "#
-            .to_string(),
-        )
-        .unwrap();
+        "#;
+        assert!(!is_reachable(code, "bar", "foo"));
+    }
+
+    /// Check if the `origin` node is able to reach the `target` node.
+    fn is_reachable(code: &str, origin: &str, target: &str) -> bool {
+        // Find node ranges for start and end.
+        let mut origin_range = None;
+        let mut target_range = None;
+        for (i, line) in code.lines().enumerate() {
+            if let Some(offset) = line.find(origin).filter(|_| origin_range.is_none()) {
+                let start = Point::new(i, offset);
+                let end = Point::new(i, offset + origin.len());
+                origin_range = Some((start, end));
+            }
+
+            if let Some(offset) = line.find(target).filter(|_| target_range.is_none()) {
+                let start = Point::new(i, offset);
+                let end = Point::new(i, offset + origin.len());
+                target_range = Some((start, end));
+            }
+        }
+
+        let origin_range = origin_range.unwrap();
+        let target_range = target_range.unwrap();
+
+        // Create access graph.
+        let tree = Tree::new(code.into()).unwrap();
         let st = SymbolTable::new(&tree);
         let accesses = AccessGraph::new(&tree, &st);
 
-        // The `foo` function
-        let foo = tree
-            .root_node()
-            .descendant_for_point_range(Point::new(1, 21), Point::new(1, 24))
-            .unwrap();
+        // Get the tree nodes for the origin and target.
+        let origin_node =
+            tree.root_node().descendant_for_point_range(origin_range.0, origin_range.1).unwrap();
+        let target_node =
+            tree.root_node().descendant_for_point_range(target_range.0, target_range.1).unwrap();
 
-        // The `bar` function
-        let bar = tree
-            .root_node()
-            .descendant_for_point_range(Point::new(3, 21), Point::new(0, 24))
-            .unwrap();
+        // Ensure origin can reach target.
+        let paths =
+            accesses.compute_paths(|access| access.node == origin_node, target_node).unwrap();
 
-        let paths = accesses.compute_paths(|access| access.node == bar, foo).unwrap();
-        println!("{paths:#?}");
-        assert!(paths.is_empty());
+        !paths.is_empty()
     }
 }

--- a/vuln-reach/src/javascript/lang/accesses.rs
+++ b/vuln-reach/src/javascript/lang/accesses.rs
@@ -487,6 +487,21 @@ mod tests {
 
     #[ignore]
     #[test]
+    fn renamed_function() {
+        let code = r#"
+            function foo() { }
+
+            renamed = foo;
+
+            function bar() {
+                renamed();
+            }
+        "#;
+        assert!(is_reachable(code, "bar", "foo"));
+    }
+
+    #[ignore]
+    #[test]
     fn leaked_renamed_function() {
         let code = r#"
             function foo() { }

--- a/vuln-reach/src/javascript/lang/symbol_table.rs
+++ b/vuln-reach/src/javascript/lang/symbol_table.rs
@@ -139,7 +139,7 @@ impl<'a> SymbolTableBuilder<'a> {
                     }
                     let name = declarator_node.child_by_field_name(b"name").unwrap();
                     let scope = self.find_parent_function_scope().unwrap();
-                    scope.names.insert(name);
+                    scope.define(name);
                 }
 
                 self.visit_children(node);
@@ -153,7 +153,7 @@ impl<'a> SymbolTableBuilder<'a> {
                     }
                     let scope = self.scope_stack.last_mut().unwrap();
                     let name = declarator_node.child_by_field_name(b"name").unwrap();
-                    scope.names.insert(name);
+                    scope.define(name);
                 }
 
                 self.visit_children(node);
@@ -163,7 +163,7 @@ impl<'a> SymbolTableBuilder<'a> {
                 let scope = self.scope_stack.last_mut().unwrap();
                 for i in 0..node.named_child_count() {
                     let parameter_name = node.named_child(i).unwrap();
-                    scope.names.insert(parameter_name);
+                    scope.define(parameter_name);
                 }
             },
             "catch_clause" => {
@@ -172,7 +172,7 @@ impl<'a> SymbolTableBuilder<'a> {
                     self.visit(catch_statement);
                     let scope = self.scope_stack.last_mut().unwrap();
                     if let Some(catch_param) = node.child_by_field_name(b"parameter") {
-                        scope.names.insert(catch_param);
+                        scope.define(catch_param);
                     }
                 }
             },
@@ -184,7 +184,7 @@ impl<'a> SymbolTableBuilder<'a> {
 
                 let name = node.child_by_field_name(b"name").unwrap();
                 let alias = node.child_by_field_name(b"alias");
-                scope.names.insert(alias.unwrap_or(name));
+                scope.define(alias.unwrap_or(name));
 
                 self.visit_children(node);
             },
@@ -199,7 +199,7 @@ impl<'a> SymbolTableBuilder<'a> {
                 for i in 0..node.named_child_count() {
                     let identifier = node.named_child(i).unwrap();
                     if identifier.kind() == "identifier" {
-                        scope.names.insert(identifier);
+                        scope.define(identifier);
                     }
                 }
 


### PR DESCRIPTION
Previously when an anonymous function or lambda was used, its body would be considered completely unreachable.

This patch adds support for both immediately executed lambdas and lambdas with deferred execution by assignment to a temporary variable.

It also fixes an issue where immediately executed named functions weren't considered reachable.

Closes #36.