### PR TITLE
Add end position to vulnerable nodes

### DIFF
--- a/vuln-reach-cli/README.md
+++ b/vuln-reach-cli/README.md
@@ -30,7 +30,7 @@ packages = [
   { name = "generic-pool", version = "3.8.2" },
 ]
 vuln = [
-  { package = "generic-pool", module = "lib/Pool.js", row = 743, column = 17 }
+  { package = "generic-pool", module = "lib/Pool.js", start_row = 743, start_column = 17, end_row = 743, end_column = 21 }
 ]
 
 [[projects]]
@@ -42,7 +42,7 @@ packages = [
   { name = "minipass", version = "4.0.2" },
 ]
 vuln = [
-  { package = "lru-cache", module = "index.js", row = 1017, column = 24 }
+  { package = "lru-cache", module = "index.js", start_row = 1017, start_column = 17, end_row = 1017, end_column = 24 }
 ]
 ```
 

--- a/vuln-reach-cli/sample.toml
+++ b/vuln-reach-cli/sample.toml
@@ -8,7 +8,7 @@ packages = [
   { name = "generic-pool", version = "3.8.2" },
 ]
 vuln = [
-  { package = "generic-pool", module = "lib/Pool.js", row = 743, column = 17 }
+  { package = "generic-pool", module = "lib/Pool.js", start_row = 743, start_column = 17, end_row = 743, end_column = 21 }
 ]
 
 [[projects]]
@@ -20,5 +20,5 @@ packages = [
   { name = "minipass", version = "4.0.2" },
 ]
 vuln = [
-  { package = "lru-cache", module = "index.js", row = 1017, column = 24 }
+  { package = "lru-cache", module = "index.js", start_row = 1017, start_column = 17, end_row = 1017, end_column = 24 }
 ]

--- a/vuln-reach-cli/src/main.rs
+++ b/vuln-reach-cli/src/main.rs
@@ -124,8 +124,8 @@ impl ProjectDef {
                         "\n\x1b[31m  *** Node {}/{}:{}:{} is reachable!\x1b[0m\n",
                         node.package(),
                         node.module(),
-                        node.row(),
-                        node.column()
+                        node.start_row(),
+                        node.start_column()
                     );
                     print_path(path);
                 },
@@ -134,8 +134,8 @@ impl ProjectDef {
                         "\n\x1b[33m  *** No paths to {}/{}:{}:{} found.\x1b[0m",
                         node.package(),
                         node.module(),
-                        node.row(),
-                        node.column()
+                        node.start_row(),
+                        node.start_column()
                     );
                 },
             }

--- a/vuln-reach/src/javascript/package/reachability.rs
+++ b/vuln-reach/src/javascript/package/reachability.rs
@@ -178,9 +178,13 @@ pub struct VulnerableNode {
     /// The module specifier.
     module: String,
     /// The starting row (zero-indexed).
-    row: usize,
+    start_row: usize,
     /// The starting column (zero-indexed).
-    column: usize,
+    start_column: usize,
+    /// The ending row (zero-indexed).
+    end_row: usize,
+    /// The ending column (zero-indexed).
+    end_column: usize,
 }
 
 impl VulnerableNode {
@@ -188,10 +192,19 @@ impl VulnerableNode {
     pub fn new<P: Into<String>, M: Into<String>>(
         package: P,
         module: M,
-        row: usize,
-        column: usize,
+        start_row: usize,
+        start_column: usize,
+        end_row: usize,
+        end_column: usize,
     ) -> Self {
-        Self { package: package.into(), module: module.into(), row, column }
+        Self {
+            package: package.into(),
+            module: module.into(),
+            start_row,
+            start_column,
+            end_row,
+            end_column,
+        }
     }
 
     pub fn package(&self) -> &str {
@@ -202,12 +215,20 @@ impl VulnerableNode {
         &self.module
     }
 
-    pub fn row(&self) -> usize {
-        self.row
+    pub fn start_row(&self) -> usize {
+        self.start_row
     }
 
-    pub fn column(&self) -> usize {
-        self.column
+    pub fn start_column(&self) -> usize {
+        self.start_column
+    }
+
+    pub fn end_row(&self) -> usize {
+        self.end_row
+    }
+
+    pub fn end_column(&self) -> usize {
+        self.end_column
     }
 }
 
@@ -326,8 +347,8 @@ impl PackageReachability {
             .tree()
             .root_node()
             .descendant_for_point_range(
-                Point::new(vuln_node.row, vuln_node.column),
-                Point::new(vuln_node.row, vuln_node.column),
+                Point::new(vuln_node.start_row, vuln_node.start_column),
+                Point::new(vuln_node.start_row, vuln_node.start_column),
             )
             .ok_or_else(|| Error::Generic(format!("Node not found: {vuln_node:?}")))?;
         let paths_to_exports = module.paths_to_exports(vuln_ts_node)?;
@@ -728,7 +749,7 @@ mod tests {
         let package = fixture_esm_package1();
         let r = PackageReachability::new(
             &package,
-            &VulnerableNode::new("fixture", "source3.mjs".to_string(), 1, 10),
+            &VulnerableNode::new("fixture", "source3.mjs".to_string(), 1, 9, 1, 16),
         )
         .unwrap();
         println!("{r:#?}");
@@ -752,7 +773,7 @@ mod tests {
         let package = fixture_esm_package1();
         let r = PackageReachability::new(
             &package,
-            &VulnerableNode::new("fixture", "source3.mjs".to_string(), 1, 10),
+            &VulnerableNode::new("fixture", "source3.mjs".to_string(), 1, 9, 1, 16),
         )
         .unwrap();
 
@@ -764,7 +785,7 @@ mod tests {
         let package = fixture_cjs_package1();
         let r = PackageReachability::new(
             &package,
-            &VulnerableNode::new("fixture", "source3.js".to_string(), 1, 10),
+            &VulnerableNode::new("fixture", "source3.js".to_string(), 1, 9, 1, 16),
         )
         .unwrap();
         println!("{r:#?}");

--- a/vuln-reach/src/javascript/project/mod.rs
+++ b/vuln-reach/src/javascript/project/mod.rs
@@ -312,13 +312,16 @@ impl<R: ModuleResolver> Project<R> {
                     // target nodes, and attach information about the imported
                     // symbol.
                     if reachability_check {
-                        let pos = node.start_position();
+                        let start_pos = node.start_position();
+                        let end_pos = node.end_position();
                         target_nodes.push((
                             VulnerableNode::new(
                                 package_spec,
                                 module_spec.to_string_lossy(),
-                                pos.row,
-                                pos.column,
+                                start_pos.row,
+                                start_pos.column,
+                                end_pos.row,
+                                end_pos.column,
                             ),
                             Some(VulnerableEdge::new(dep_package, dep_module)),
                         ));
@@ -555,7 +558,7 @@ mod tests {
         let project = project_trivial_esm();
 
         let r = project.reachability_inner(
-            &VulnerableNode::new("dependency", "vuln.js", 1, 31),
+            &VulnerableNode::new("dependency", "vuln.js", 1, 31, 1, 34),
             Default::default(),
         );
         let path = r.find_path("dependent").unwrap();
@@ -568,7 +571,7 @@ mod tests {
         let project = project_trivial_cjs();
 
         let r = project.reachability_inner(
-            &VulnerableNode::new("dependency", "vuln.js", 1, 41),
+            &VulnerableNode::new("dependency", "vuln.js", 1, 41, 1, 44),
             Default::default(),
         );
         let path = r.find_path("dependent").unwrap();


### PR DESCRIPTION
Closes #30.

This is a breaking change in the public API and we will have to make changes to `vuln-reach`'s dependents; we can hold off on merging this in until we are ready to do that.