### PR TITLE
Fix global variable hoisting

### DIFF
--- a/vuln-reach/src/javascript/lang/accesses.rs
+++ b/vuln-reach/src/javascript/lang/accesses.rs
@@ -112,7 +112,7 @@ impl<'a> AccessGraph<'a> {
 
                 let decl_scope = decl_scope.node();
 
-                // Get the accessor as defined by the method.
+                // Get the scope of the next parent accessing this node.
                 let accessor = AccessGraph::find_accessor(symbol_table, &mut cursor_cache, node)
                     .and_then(|node| {
                         let cursor = cursor_cache.cursor(node).ok()?;
@@ -485,7 +485,6 @@ mod tests {
         assert!(is_reachable(code, "bar", "foo"));
     }
 
-    #[ignore]
     #[test]
     fn renamed_function() {
         let code = r#"

--- a/vuln-reach/src/javascript/lang/symbol_table.rs
+++ b/vuln-reach/src/javascript/lang/symbol_table.rs
@@ -70,7 +70,6 @@ impl<'a> SymbolTableBuilder<'a> {
             for name in assignments {
                 let cursor = Cursor::new(tree, name).unwrap();
                 if table.lookup(cursor).is_none() {
-                    println!("HOISTING {:?}", name);
                     table.scopes[0].define(name);
                 }
             }

--- a/vuln-reach/src/javascript/module/mod.rs
+++ b/vuln-reach/src/javascript/module/mod.rs
@@ -333,7 +333,6 @@ mod tests {
             )
             .unwrap();
 
-        println!("PATHS: {:?}", paths);
         assert!(paths.len() == 1, "Wrong number of paths found");
 
         let Some(PathToExport::SideEffect { name, access_path, effect_node }) =

--- a/vuln-reach/src/javascript/module/mod.rs
+++ b/vuln-reach/src/javascript/module/mod.rs
@@ -333,11 +333,12 @@ mod tests {
             )
             .unwrap();
 
+        println!("PATHS: {:?}", paths);
         assert!(paths.len() == 1, "Wrong number of paths found");
 
         let Some(PathToExport::SideEffect { name, access_path, effect_node }) =
             paths.into_iter().next() else {
-                panic!("Path found is not to a side effect") 
+                panic!("Path found is not to a side effect")
             };
 
         assert_eq!(name, "foo", "Wrong side effect name {name}");


### PR DESCRIPTION
This fixes an issue where assignments without declaration wouldn't be correctly considered to be part of the global scope, despite JavaScript hoisting any assignment without declaration by default.

In theory the hoisting only happens when an assignment is executed, so the following code alone is not sufficient to define the global `test`:

```js
function foo() {
    test = 5;
}
```

However any code executing this function `foo` will permanently hoist `test` to be a global variable. With our current symbol table representation, the only viable way to map this is to assume `test` is always a variable assigned in the global `program` scope.

This hoisting behavior can be suppressed retroactively by declaring the variable using the `var` keyword. Retroactive declaration does not work with `let` or `const`. This is why finding the globally hoisted variables requires finding any potential `var` declarations in the current scope first.

Closes #42.