### PR TITLE
Remove assertions

### DIFF
--- a/vuln-reach-cli/src/main.rs
+++ b/vuln-reach-cli/src/main.rs
@@ -114,7 +114,7 @@ impl ProjectDef {
 
         // Compute reachability for each node.
         for node in &self.vuln {
-            let reachability = project.reachability(node);
+            let reachability = project.reachability(node)?;
 
             let path = reachability.find_path(&self.name);
 

--- a/vuln-reach/src/javascript/lang/symbol_table.rs
+++ b/vuln-reach/src/javascript/lang/symbol_table.rs
@@ -368,9 +368,7 @@ impl<'a> SymbolTable<'a> {
             let body = grandparent.child_by_field_name("body").unwrap();
 
             if body.kind() == "statement_block" {
-                // Get scope and ensure the identifier is defined in it.
                 let scope = self.get_scope(body).unwrap();
-                assert!(scope.names.iter().any(|&node| self.tree.repr_of(node) == name));
 
                 return Some((scope, node));
             } else {
@@ -385,10 +383,7 @@ impl<'a> SymbolTable<'a> {
         if parent.kind() == "catch_clause" {
             // Get catch body.
             let body = parent.child_by_field_name("body").unwrap();
-
-            // Get scope and ensure the identifier is defined in it.
             let scope = self.get_scope(body).unwrap();
-            assert!(scope.names.iter().any(|&node| self.tree.repr_of(node) == name));
 
             return Some((scope, node));
         }


### PR DESCRIPTION
This PR removes some unhelpful assertions and makes the `topological_sort` function and the `Project::reachability` methods fallible. With this PR, assertions and panics only remain in tests.

Closes #26.