### PR TITLE
Add statistics to benchmark harness

### DIFF
--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -1,5 +1,7 @@
 //! Benchmark module loading performance.
 
+use std::time::Duration;
+
 use bytes::Bytes;
 use vuln_reach::javascript::module::TarballModuleResolver;
 use vuln_reach::javascript::package::Package;
@@ -10,6 +12,8 @@ const PACKAGES: &str = include_str!("../packages");
 
 #[tokio::main]
 async fn main() {
+    let mut perf_changes: Vec<f64> = Vec::with_capacity(PACKAGES.lines().count());
+
     for package_uri in PACKAGES.lines() {
         // Ignore packages which are commented out.
         if package_uri.starts_with('#') | package_uri.trim().is_empty() {
@@ -21,32 +25,59 @@ async fn main() {
         let tarball = reqwest::get(package_uri).await.unwrap().bytes().await.unwrap();
 
         // Time loading HEAD.
-        let package = package(&tarball);
+        let (package, elapsed) = package(&tarball);
 
         // Time loading upstream.
-        let upstream_package = upstream_package(&tarball);
+        let (upstream_package, upstream_elapsed) = upstream_package(&tarball);
 
         // Ensure equivalence.
         assert_eq(upstream_package, package);
+
+        // Compute and store percentage change. Negative numbers mean faster HEAD.
+        let elapsed = elapsed.as_secs_f64();
+        let upstream_elapsed = upstream_elapsed.as_secs_f64();
+        let pct_change = elapsed / upstream_elapsed - 1f64;
+
+        println!(
+            "\x1b[{};1m  {:.2}%\x1b[0m {}",
+            if pct_change < 0. { 32 } else { 31 },
+            pct_change.abs() * 100.,
+            if pct_change < 0. { "improvement" } else { "regression" }
+        );
+
+        perf_changes.push(pct_change);
     }
+
+    let mean: f64 = perf_changes.iter().copied().sum::<f64>() / perf_changes.len() as f64;
+    let std: f64 = perf_changes.iter().copied().map(|val| (val - mean).powf(2f64)).sum::<f64>()
+        / (perf_changes.len() - 1) as f64;
+
+    println!(
+        "\nMean: {:5.2}% {}\n Std: {:5.2}",
+        mean * 100.,
+        if mean < 0. { "improvement" } else { "regression" },
+        std * 100.
+    );
 }
 
 // Load package for the current revision.
-fn package(tarball: &Bytes) -> Package<TarballModuleResolver> {
+fn package(tarball: &Bytes) -> (Package<TarballModuleResolver>, Duration) {
     let start = std::time::Instant::now();
     let package = Package::from_tarball_bytes(tarball.to_vec()).unwrap();
-    println!("  HEAD loaded in {:?}", start.elapsed());
+    let elapsed = start.elapsed();
+    println!("  HEAD loaded in {:?}", elapsed);
 
-    package
+    (package, elapsed)
 }
 
 // Load package for the upstream revision.
-fn upstream_package(tarball: &Bytes) -> UpstreamPackage<UpstreamTarballModuleResolver> {
+fn upstream_package(tarball: &Bytes) -> (UpstreamPackage<UpstreamTarballModuleResolver>, Duration) {
     let start = std::time::Instant::now();
     let package = UpstreamPackage::from_tarball_bytes(tarball.to_vec()).unwrap();
-    println!("  Upstream loaded in {:?}", start.elapsed());
+    let elapsed = start.elapsed();
+    println!("  Upstream loaded in {:?}", elapsed);
 
-    package
+    (package, elapsed)
 }
 
 // Check for equivalence of upstream/HEAD.

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -33,7 +33,9 @@ async fn main() {
         // Ensure equivalence.
         assert_eq(upstream_package, package);
 
-        // Compute and store percentage change. Negative numbers mean faster HEAD.
+        // Compute and store percentage change.
+        // If the package was loaded faster with HEAD than with upstream, the
+        // change will be a negative value.
         let elapsed = elapsed.as_secs_f64();
         let upstream_elapsed = upstream_elapsed.as_secs_f64();
         let pct_change = elapsed / upstream_elapsed - 1f64;

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -49,8 +49,9 @@ async fn main() {
     }
 
     let mean: f64 = perf_changes.iter().copied().sum::<f64>() / perf_changes.len() as f64;
-    let std: f64 = perf_changes.iter().copied().map(|val| (val - mean).powf(2f64)).sum::<f64>()
-        / (perf_changes.len() - 1) as f64;
+    let std: f64 = (perf_changes.iter().copied().map(|val| (val - mean).powf(2f64)).sum::<f64>()
+        / (perf_changes.len() - 1) as f64)
+        .sqrt();
 
     println!(
         "\nMean: {:5.2}% {}\n Std: {:5.2}",

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -26,9 +26,11 @@ async fn main() {
 
         // Time loading HEAD.
         let (package, elapsed) = package(&tarball);
+        println!("  HEAD loaded in {:?}", elapsed);
 
         // Time loading upstream.
         let (upstream_package, upstream_elapsed) = upstream_package(&tarball);
+        println!("  Upstream loaded in {:?}", upstream_elapsed);
 
         // Ensure equivalence.
         assert_eq(upstream_package, package);
@@ -68,7 +70,6 @@ fn package(tarball: &Bytes) -> (Package<TarballModuleResolver>, Duration) {
     let start = std::time::Instant::now();
     let package = Package::from_tarball_bytes(tarball.to_vec()).unwrap();
     let elapsed = start.elapsed();
-    println!("  HEAD loaded in {:?}", elapsed);
 
     (package, elapsed)
 }
@@ -78,7 +79,6 @@ fn upstream_package(tarball: &Bytes) -> (UpstreamPackage<UpstreamTarballModuleRe
     let start = std::time::Instant::now();
     let package = UpstreamPackage::from_tarball_bytes(tarball.to_vec()).unwrap();
     let elapsed = start.elapsed();
-    println!("  Upstream loaded in {:?}", elapsed);
 
     (package, elapsed)
 }


### PR DESCRIPTION
This PR adds code to collect percentage changes in performance in the benchmark harness. 
After the benchmarks have run, the mean and the standard deviation of the changes are reported.