### PR TITLE
Bump `ouroboros` to 0.17

### DIFF
--- a/vuln-reach/Cargo.toml
+++ b/vuln-reach/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 flate2 = "1.0.24"
 itertools = "0.10.5"
 lazy_static = "1.4.0"
-ouroboros = "0.15.5"
+ouroboros = "0.17.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 tar = "0.4.38"

--- a/vuln-reach/src/javascript/lang/exports.rs
+++ b/vuln-reach/src/javascript/lang/exports.rs
@@ -10,15 +10,19 @@ use crate::{Error, Tree, JS};
 //
 // All the compatible export statements in CommonJS are the following:
 // 1. module.exports = an object, an identifier, or a function
+//
 //    When this is found, override all previous exports.
+//
 // 2. module.exports.foo = anything
+//
 //    When this is found, override exports of the same name only.
+//
 // 3. exports.foo = anything
-//    This is compatible with 2., but if there is even one instance
-//    of 1., this definition does nothing. This is because the
-//    module-global `exports` is a shorthand for `module.exports`,
-//    but if something is assigned to `module.exports`, this simply
-//    gets cloaked and the reference gets lost.
+//
+//    This is compatible with 2., but if there is even one instance of 1., this
+//    definition does nothing. This is because the module-global `exports` is a
+//    shorthand for `module.exports`, but if something is assigned to
+//    `module.exports`, this simply gets cloaked and the reference gets lost.
 //
 // For the time, we only care about top-level exported objects,
 // i.e.:


### PR DESCRIPTION
This PR bumps the `ouroboros` dependency to the version 0.17, which solves a [soundness issue](https://github.com/joshua-maros/ouroboros/issues/88).