### PR TITLE
Remove unnecessary argument from `Project` constructor

### DIFF
--- a/vuln-reach-cli/src/main.rs
+++ b/vuln-reach-cli/src/main.rs
@@ -106,11 +106,9 @@ impl ProjectDef {
         }
 
         let package_resolver = package_resolver.build();
-        let packages =
-            self.packages.iter().map(|PackageDef { name, .. }| name.clone()).collect::<Vec<_>>();
 
         // Build the project object.
-        let project = Project::new(package_resolver, packages);
+        let project = Project::new(package_resolver);
 
         // Compute reachability for each node.
         for node in &self.vuln {

--- a/vuln-reach/src/javascript/package/resolver.rs
+++ b/vuln-reach/src/javascript/package/resolver.rs
@@ -61,6 +61,10 @@ where
 
         Some((package, module))
     }
+
+    pub fn package_specs(&self) -> impl Iterator<Item = &String> {
+        self.packages.keys()
+    }
 }
 
 /// Builder for [`PackageResolver`].

--- a/vuln-reach/src/javascript/project/mod.rs
+++ b/vuln-reach/src/javascript/project/mod.rs
@@ -156,12 +156,11 @@ impl ProjectReachability {
 
 pub struct Project<R: ModuleResolver> {
     package_resolver: PackageResolver<R>,
-    packages: Vec<String>,
 }
 
 impl<R: ModuleResolver> Project<R> {
-    pub fn new(package_resolver: PackageResolver<R>, packages: Vec<String>) -> Self {
-        Self { package_resolver, packages }
+    pub fn new(package_resolver: PackageResolver<R>) -> Self {
+        Self { package_resolver }
     }
 
     pub fn reachability(&self, vuln_node: &VulnerableNode) -> Result<ProjectReachability> {
@@ -177,8 +176,8 @@ impl<R: ModuleResolver> Project<R> {
     }
 
     pub fn all_packages(&self) -> Vec<(&str, &Package<R>)> {
-        self.packages
-            .iter()
+        self.package_resolver
+            .package_specs()
             .filter_map(|package_spec| {
                 self.package_resolver
                     .resolve_package(package_spec)
@@ -497,7 +496,7 @@ mod tests {
             )
             .build();
 
-        Project { package_resolver, packages: vec!["dependency".into(), "dependent".into()] }
+        Project { package_resolver }
     }
 
     fn project_trivial_cjs() -> Project<MemModuleResolver> {
@@ -529,7 +528,7 @@ mod tests {
             )
             .build();
 
-        Project { package_resolver, packages: vec!["dependency".into(), "dependent".into()] }
+        Project { package_resolver }
     }
 
     #[test]


### PR DESCRIPTION
This PR simplifies the public API of the `Project` object, by removing the `packages` argument and allowing the packages list to be inferred from the package resolver.

Closes #11.