### PR TITLE
Change `find_accessor` to only emit identifiers

### DIFF
--- a/vuln-reach/src/javascript/lang/accesses.rs
+++ b/vuln-reach/src/javascript/lang/accesses.rs
@@ -405,6 +405,21 @@ mod tests {
         assert!(is_accessor(code, (3, 30, 32), Some((2, 21, 23))));
     }
 
+    #[test]
+    fn accessor_assignment_expressions() {
+        let code = r#"
+            function foo() {
+                let bar = baz
+                bar = baz
+                bar += baz
+            }
+        "#;
+
+        assert!(is_accessor(code, (2, 20, 22), Some((1, 21, 23))));
+        assert!(is_accessor(code, (3, 16, 18), Some((1, 21, 23))));
+        assert!(is_accessor(code, (4, 16, 18), Some((1, 21, 23))));
+    }
+
     // Check if the accessor of the node is the expected one.
     //
     // As identifiers can't span more than one row, they are specified as

--- a/vuln-reach/src/javascript/lang/accesses.rs
+++ b/vuln-reach/src/javascript/lang/accesses.rs
@@ -384,8 +384,8 @@ mod tests {
 
         // The `foo` declaration has no accessor.
         assert!(is_accessor(code, (1, 21, 23), None));
-        // The `bar` declaration has no accessor.
-        assert!(is_accessor(code, (2, 25, 27), None));
+        // The `bar` declaration has `foo` as accessor.
+        assert!(is_accessor(code, (2, 25, 27), Some((1, 21, 23))));
         // The `bar` node in `quux = bar` has `quux` as accessor.
         assert!(is_accessor(code, (5, 27, 29), Some((5, 20, 24))));
         // The `quux` node has the `foo` declaration as accessor.

--- a/vuln-reach/src/javascript/lang/accesses.rs
+++ b/vuln-reach/src/javascript/lang/accesses.rs
@@ -172,10 +172,12 @@ impl<'a> AccessGraph<'a> {
             match parent.kind() {
                 // Check node to avoid declarations using themselves as accessor.
                 "class_declaration" | "function_declaration" => {
-                    return parent.child_by_field_name("name").filter(|&name| name != node);
+                    if let Some(accessor) =
+                        parent.child_by_field_name("name").filter(|&name| name != node)
+                    {
+                        return Some(accessor);
+                    }
                 },
-                // Find the next parent identifier if node is an anonymous declaration.
-                "class" | "function" | "arrow_function" => (),
                 kind @ ("variable_declarator"
                 | "assignment_expression"
                 | "augmented_assignment_expression") => {


### PR DESCRIPTION
This PR changes the `AccessGraph::find_accessor` method to only emit `identifier` nodes as accessors, continuing the search upwards into the tree if that is not possible. 

Tests are added to validate that the destructuring assignments work as intended. A failing, ignored test is also added to document that we currently don't handle shorthand identifiers correctly.

Closes #48.