### PR TITLE
Simplify root scope retrieval

### DIFF
--- a/vuln-reach/src/javascript/lang/symbol_table.rs
+++ b/vuln-reach/src/javascript/lang/symbol_table.rs
@@ -96,7 +96,7 @@ impl<'a> SymbolTableBuilder<'a> {
 
     /// Retrieve the root scope.
     fn root_scope(&mut self) -> &mut Scope<'a> {
-        self.scope_stack.iter_mut().find(|scope| scope.level == 0).unwrap()
+        self.scope_stack.first_mut().unwrap()
     }
 
     // Starting from the end of the scope stack, find the first scope that's a


### PR DESCRIPTION
This PR simplifies the `SymbolTableBuilder::root_scope` method.
The assumption that `self.scope_stack.first_mut().unwrap().level() == 0` was validated by adding an assertion, running the unit tests and the benchmarks, and observing that the assertion never failed.

Closes #49.