### PR TITLE
Enhance default exports

### DIFF
--- a/vuln-reach/src/javascript/lang/exports.rs
+++ b/vuln-reach/src/javascript/lang/exports.rs
@@ -203,6 +203,16 @@ impl<'a> EsmExport<'a> {
             EsmExport::Name(node) | EsmExport::Scope(node) | EsmExport::Expression(node) => *node,
         }
     }
+
+    // Determine if the expression export contains the specified node.
+    pub fn expression_contains(&self, node: Node<'a>) -> bool {
+        match self {
+            EsmExport::Name(_) | EsmExport::Scope(_) => false,
+            EsmExport::Expression(export) => {
+                export.start_byte() <= node.start_byte() && export.end_byte() >= node.end_byte()
+            },
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/vuln-reach/src/javascript/package/reachability.rs
+++ b/vuln-reach/src/javascript/package/reachability.rs
@@ -775,22 +775,19 @@ mod tests {
         println!("{r:#?}");
         println!("{r}");
 
-        assert_eq!(
-            r.reachable_exports(),
-            hashset! {
-                ("source1.mjs", "reaches1"),
-                ("source1.mjs", "reaches2"),
-                ("source1.mjs", "reaches3"),
-                ("source3.mjs", "reaches"),
-                ("source4.mjs", "reaches"),
-                ("index.mjs", "explicit_export"),
-                ("index.mjs", "reaches"),
-                ("index.mjs", "reaches2"),
-                ("index.mjs", "source4"),
-                ("index.mjs", "source5"),
-                ("source5.mjs", "foo"),
-            }
-        );
+        assert_eq!(r.reachable_exports(), hashset! {
+            ("source1.mjs", "reaches1"),
+            ("source1.mjs", "reaches2"),
+            ("source1.mjs", "reaches3"),
+            ("source3.mjs", "reaches"),
+            ("source4.mjs", "reaches"),
+            ("index.mjs", "explicit_export"),
+            ("index.mjs", "reaches"),
+            ("index.mjs", "reaches2"),
+            ("index.mjs", "source4"),
+            ("index.mjs", "source5"),
+            ("source5.mjs", "foo"),
+        });
     }
 
     #[test]

--- a/vuln-reach/src/javascript/package/reachability.rs
+++ b/vuln-reach/src/javascript/package/reachability.rs
@@ -700,7 +700,6 @@ mod tests {
         }
 
         {
-            println!("{:#?}", paths);
             let paths = paths.get(&("index.mjs", "source5.mjs")).unwrap();
             assert_eq!(
                 paths.iter().map(|p| p.name()).collect::<HashSet<_>>(),
@@ -776,19 +775,22 @@ mod tests {
         println!("{r:#?}");
         println!("{r}");
 
-        assert_eq!(r.reachable_exports(), hashset! {
-            ("source1.mjs", "reaches1"),
-            ("source1.mjs", "reaches2"),
-            ("source1.mjs", "reaches3"),
-            ("source3.mjs", "reaches"),
-            ("source4.mjs", "reaches"),
-            ("index.mjs", "explicit_export"),
-            ("index.mjs", "reaches"),
-            ("index.mjs", "reaches2"),
-            ("index.mjs", "source4"),
-            ("index.mjs", "source5"),
-            ("source5.mjs", "foo"),
-        });
+        assert_eq!(
+            r.reachable_exports(),
+            hashset! {
+                ("source1.mjs", "reaches1"),
+                ("source1.mjs", "reaches2"),
+                ("source1.mjs", "reaches3"),
+                ("source3.mjs", "reaches"),
+                ("source4.mjs", "reaches"),
+                ("index.mjs", "explicit_export"),
+                ("index.mjs", "reaches"),
+                ("index.mjs", "reaches2"),
+                ("index.mjs", "source4"),
+                ("index.mjs", "source5"),
+                ("source5.mjs", "foo"),
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
This PR addresses the default exports underspecification as per #47.

Default ESM export nodes are now renamed as `default` with the appropriate guard conditions.

Closes #47.